### PR TITLE
グループ作成・編集機能におけるビュー素材の修正

### DIFF
--- a/edit.html.erb
+++ b/edit.html.erb
@@ -7,7 +7,7 @@
         <li>エラーです</li>
       </ul>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
         <label class="chat-group-form__label" for="chat_group_name">グループ名</label>
       </div>
@@ -15,15 +15,15 @@
         <input class="chat-group-form__input" placeholder="グループ名を入力してください" type="text" value="ほげー" name="chat_group[name]" id="chat_group_name" />
       </div>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します  -->
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
         <label class="chat-group-form__label" for="chat_group_チャットメンバー">チャットメンバー</label>
       </div>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'></div>
       <div class='chat-group-form__field--right'>
         <!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください  -->

--- a/edit.html.erb
+++ b/edit.html.erb
@@ -1,6 +1,6 @@
 <div class='chat-group-form'>
   <h1>チャットグループ編集</h1>
-  <form class="edit_chat_group" id="edit_chat_group_22" action="/chat_groups/22" accept-charset="UTF-8" method="post">
+  <form>
     <div class="chat-group-form__errors">
       <h2>1件のエラーが発生しました。
       <ul>
@@ -12,7 +12,7 @@
         <label class="chat-group-form__label" for="chat_group_name">グループ名</label>
       </div>
       <div class='chat-group-form__field--right'>
-        <input class="chat-group-form__input" placeholder="グループ名を入力してください" type="text" value="ほげー" name="chat_group[name]" id="chat_group_name" />
+        <input class="chat-group-form__input" placeholder="グループ名を入力してください" type="text" name="chat_group[name]" id="chat_group_name" />
       </div>
     </div>
     <div class='chat-group-form__field'>
@@ -20,14 +20,16 @@
     </div>
     <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバー">チャットメンバー</label>
+        <label class="chat-group-form__label">チャットメンバー</label>
+      </div>
+      <div class='chat-group-form__field--right'>
+        <!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください  -->
+        <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します  -->
       </div>
     </div>
     <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'></div>
       <div class='chat-group-form__field--right'>
-        <!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください  -->
-        <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します  -->
         <input type="submit" name="commit" value="Save" class="chat-group-form__action-btn" data-disable-with="Save" />
       </div>
     </div>

--- a/group.scss
+++ b/group.scss
@@ -1,3 +1,29 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
 .chat-group-form {
   width: 980px;
   margin: 60px auto;
@@ -6,112 +32,76 @@
   border: 1px solid #ddd;
   border-radius: 5px;
   box-sizing: border-box;
-
-  h1 {
-    letter-spacing: 2px;
-    font-size: 24px;
-    font-weight: bold;
-    text-align: center;
-  }
-
-  .chat-group-form__errors {
+  &__errors {
     margin: 30px 0;
     padding: 20px 40px;
     border: 1px solid #ddd;
     border-radius: 2px;
     text-align: center;
-
-    h2 {
-      margin-bottom: 10px;
-      color: #f05050;
-      font-size: 14px;
-    }
-
-    ul {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    li {
-      margin: 0;
-      padding: 0;
-      font-size: 13px;
-    }
   }
-
-  .chat-group-form__field {
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
     margin-top: 30px;
     &:after {
       content: "";
       clear: both;
       display: block;
     }
-
-    .chat-group-form__field--left {
+    &--left {
       float: left;
       width: 30%;
       padding-right: 20px;
       padding-left: 20px;
       box-sizing: border-box;
     }
-
-    .chat-group-form__field--right {
+    &--right {
       float: right;
       width: 70%;
     }
-
-    .chat-group-form__label {
-      display: block;
-      line-height: 50px;
-      font-weight: bold;
-      text-align: right;
-    }
-
-    .chat-group-form__input {
-      float: left;
-      width: 100%;
-      line-height: 30px;
-      padding: 10px 15px;
-      box-sizing: border-box;
-    }
   }
+}
 
-  .chat-group-user {
-    padding: 0 15px;
-    line-height: 50px;
-    font-size: 14px;
-    border-bottom: 1px solid #ddd;
-    &:after {
-      content: "";
-      clear: both;
-      display: block;
-    }
-
-    .chat-group-user__name {
-      float: left;
-    }
-
-    .chat-group-user__btn {
-      float: right;
-      display: inline-block;
-      cursor: pointer;
-
-      &.chat-group-user__btn--add {
-        color: #38aef0;
-      }
-
-      &.chat-group-user__btn--remove {
-        color: #f05050;
-      }
-    }
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
   }
-
-  .chat-group-form__action-btn {
+  &__name {
+    float: left;
+  }
+  &__btn {
+    float: right;
     display: inline-block;
-    padding: 12px 20px;
-    color: #fff;
-    background-color: #38aef0;
-    border: 0;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
   }
 }

--- a/new.html.erb
+++ b/new.html.erb
@@ -1,6 +1,6 @@
 <div class='chat-group-form'>
   <h1>新規チャットグループ</h1>
-  <form class="new_chat_group" id="new_chat_group" action="/chat_groups" accept-charset="UTF-8" method="post">
+  <form>
     <div class="chat-group-form__errors">
       <h2>1件のエラーが発生しました。
       <ul>
@@ -20,12 +20,11 @@
     </div>
     <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバー">チャットメンバー</label>
+        <label class="chat-group-form__label">チャットメンバー</label>
       </div>
       <div class='chat-group-form__field--right'>
         <!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください  -->
         <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します  -->
-          <div class='chat-group-user' id='chat-group-user-22'>
       </div>
     </div>
     <div class='chat-group-form__field'>

--- a/new.html.erb
+++ b/new.html.erb
@@ -7,7 +7,7 @@
         <li>エラーです</li>
       </ul>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
         <label class="chat-group-form__label" for="chat_group_name">グループ名</label>
       </div>
@@ -15,20 +15,20 @@
         <input class="chat-group-form__input" placeholder="グループ名を入力してください" type="text" name="chat_group[name]" id="chat_group_name" />
       </div>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します  -->
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'>
         <label class="chat-group-form__label" for="chat_group_チャットメンバー">チャットメンバー</label>
       </div>
       <div class='chat-group-form__field--right'>
         <!-- グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください  -->
         <!-- この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します  -->
-          <div class='chat-group-user clearfix' id='chat-group-user-22'>
+          <div class='chat-group-user' id='chat-group-user-22'>
       </div>
     </div>
-    <div class='chat-group-form__field clearfix'>
+    <div class='chat-group-form__field'>
       <div class='chat-group-form__field--left'></div>
       <div class='chat-group-form__field--right'>
         <input type="submit" name="commit" value="Save" class="chat-group-form__action-btn" data-disable-with="Save" />


### PR DESCRIPTION
# why
scssの記法がアンパサンドを使用されておらず、且つ順番も入れ違っていたため、見にくかったため修正した。また、htmlファイル内では存在しないクラスを指定していたため削除した。

# what
具体的に行った修正は以下の3点

- htmlで指定されていたclearfixクラスの削除
- scssにおけるアンパサンドの導入
- scssにおける記載順列の見直し（関係の無いクラスに入れ子になっていたりした）

上記については動作確認済みです。